### PR TITLE
Allow the user more control over error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-node_modules
-*.log


### PR DESCRIPTION
Instead of returning `res.send(401)`, call `authError()`, and allow the user to handle the error.

The use case for this is to allow the user to throw a custom error in the `verify` or `lookup` functions, and handle that error, possibly sending the message back with the response. See the new test for an example of this.

This would be a major version change, since it's possible code may be relying on the previous `res.send(401)` calls, and isn't using the default `authError` function.
