### PR TITLE
Update jsonwebtoken, use expiresIn parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function expressJWT(rawOpts) {
             return createTokenError(req, res, next, err);
           }
           var token = jwt.sign(tokenData, opts.secret, {
-            expiresInMinutes: opts.tokenLife,
+            expiresIn: opts.tokenLife * 60,
             algorithm: opts.algorithm
           });
           tokenData[opts.tokenPropertyName] = token;
@@ -84,7 +84,7 @@ function expressJWT(rawOpts) {
           return refreshTokenError(req, res, next, err);
         }
         var token = jwt.sign(tokenData, opts.secret, {
-          expiresInMinutes: opts.tokenLife,
+          expiresIn: opts.tokenLife * 60,
           algorithm: opts.algorithm
         });
         tokenData[opts.tokenPropertyName] = token;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "body-parser": "^1.12.2",
     "express": "^4.12.3",
-    "jsonwebtoken": "^5.0.0"
+    "jsonwebtoken": "^5.4.0"
   },
   "devDependencies": {
     "supertest": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-simple-auth-token",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "JSON web token middleware for express designed to work with Ember Simple Auth Token",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This avoids deprecation notices when installed version of jsonwebtoken is ^5.4.0.
